### PR TITLE
Update bulk_report_generator.py

### DIFF
--- a/ws_bulk_report_generator/bulk_report_generator.py
+++ b/ws_bulk_report_generator/bulk_report_generator.py
@@ -229,8 +229,7 @@ def write_file(output: list):
         logger.debug("TBD: Converting output to Excel")
         generate_xlsx(output, full_path)
     else:
-        with open(full_path, args.write_mode) as fp:
-            fp.write(json.dumps(output))
+        json.dump(output, full_path, indent=4) 
 
     logger.info(f"Finished writing filename: '{full_path}'")
 


### PR DESCRIPTION
Changed output for json.dump to make it simpler. With the json library we don't need to dump it to a string and then write to a file, we can dump directly to the file. Added "indent=4" so that it is human readable when somebody opens the file.